### PR TITLE
fix editList and taskLists

### DIFF
--- a/src/domain/permissions-management/PermissionsServiceImpl.ts
+++ b/src/domain/permissions-management/PermissionsServiceImpl.ts
@@ -14,6 +14,8 @@ import { EditListRepository } from "../../ports/permissions-management/EditListR
 import { UserDevicePermission } from "./UserDevicePermission.js";
 import { ScriptId, TaskId } from "../scripts-management/Script.js";
 import { ScriptNotFoundError } from "../../ports/scripts-management/Errors.js";
+import { EditList } from "./EditList.js";
+import { TaskLists } from "./TaskLists.js";
 
 export class PermissionsServiceImpl implements PermissionsService {
 
@@ -128,7 +130,10 @@ export class PermissionsServiceImpl implements PermissionsService {
       Effect.flatMap(() => this.editListRepo.find(scriptId)),
       Effect.catch("__brand", {
         failure: "NotFoundError",
-        onFailure: () => Effect.fail(ScriptNotFoundError())
+        onFailure: () => { 
+          this.editListRepo.add(EditList(scriptId, []))
+          return Effect.succeed(EditList(scriptId, []));
+        }
       }),
       Effect.flatMap((editList) => {
         editList.addUserToUsers(token.userEmail);
@@ -173,7 +178,10 @@ export class PermissionsServiceImpl implements PermissionsService {
       Effect.flatMap(() => this.taskListsRepo.find(taskId)),
       Effect.catch("__brand", {
         failure: "NotFoundError",
-        onFailure: () => Effect.fail(ScriptNotFoundError())
+        onFailure: () => {
+          this.taskListsRepo.add(TaskLists(taskId, [], []))
+          return Effect.succeed(TaskLists(taskId, [], []));
+        }
       }),
       Effect.flatMap((taskList) => {
         return Effect.if(taskList.blacklist.includes(email), {
@@ -222,7 +230,10 @@ export class PermissionsServiceImpl implements PermissionsService {
       Effect.flatMap(() => this.taskListsRepo.find(taskId)),
       Effect.catch("__brand", {
         failure: "NotFoundError",
-        onFailure: () => Effect.fail(ScriptNotFoundError())
+        onFailure: () => {
+          this.taskListsRepo.add(TaskLists(taskId, [], []))
+          return Effect.succeed(TaskLists(taskId, [], []));
+        }
       }),
       Effect.flatMap((taskList) => {
         return Effect.if(taskList.whitelist.includes(email), {

--- a/test/domain/permissions-management/PermissionsService.test.ts
+++ b/test/domain/permissions-management/PermissionsService.test.ts
@@ -202,14 +202,13 @@ test("addToEditList", async () => {
     expect(editListRepo.callsToUpdate).toBe(1)
 })
 
-test("addToEditList, expect a ScriptNotFoundError", async () => {
+test("addToEditList to a list that doesn't exist", async () => {
     expect(editListRepo.callsToUpdate).toBe(0)
-    await expect(
-        Effect.runPromise(
-            service.addToEditlist(makeToken(), Email("test@test.com") ,TaskId("200")),
-        )
-    ).rejects.toThrow("ScriptNotFoundError");
-    expect(editListRepo.callsToUpdate).toBe(0)
+    await pipe(
+        service.addToEditlist(makeToken(), Email("test@test.com") ,TaskId("200")),
+        Effect.runPromise
+    );
+    expect(editListRepo.callsToUpdate).toBe(1)
 })
 
 test("addToEditList, expect a UserNotFoundError", async () => {
@@ -297,13 +296,13 @@ test("addToWhiteList", async () => {
     expect(taskListsRepo.callsToUpdate).toBe(1)
 })
 
-test("addToWhiteList, expect ScriptNotFoundError", async () => {
+test("addToWhiteList to a list that doesn't exist", async () => {
     expect(taskListsRepo.callsToUpdate).toBe(0)
-    await expect(
-        Effect.runPromise(
-            service.addToWhitelist(makeToken(), Email("test@test.com") , TaskId("200")),    
-        )
-    ).rejects.toThrow("ScriptNotFoundError");
+    await pipe(
+        service.addToWhitelist(makeToken(), Email("test@test.com") , TaskId("200")),    
+        Effect.runPromise
+    )
+    expect(taskListsRepo.callsToUpdate).toBe(1)
 })
 
 test("addToWhiteList, expect UnauthorizedError", async () => {
@@ -403,13 +402,13 @@ test("addToBlackList", async () => {
     expect(taskListsRepo.callsToUpdate).toBe(1)
 })
 
-test("addToBlackList, expect ScriptNotFoundError", async () => {
+test("addToBlackList to a list that doesn't exist", async () => {
     expect(taskListsRepo.callsToUpdate).toBe(0)
-    await expect(
-        Effect.runPromise(
-            service.addToBlacklist(makeToken(), Email("test@test.com") , TaskId("200")),
-        )
-    ).rejects.toThrow("ScriptNotFoundError");
+    await pipe(
+        service.addToBlacklist(makeToken(), Email("test@test.com") , TaskId("200")),
+        Effect.runPromise
+    );
+    expect(taskListsRepo.callsToUpdate).toBe(1)
 })
 
 test("addToBlackList, expect UserNotFoundError", async () => {


### PR DESCRIPTION
Fix editList and taskList: now a new object is created when an update is attempted with a non-existent ID.