### PR TITLE
Fix/scripts service

### DIFF
--- a/src/domain/scripts-management/ScriptBuilder.ts
+++ b/src/domain/scripts-management/ScriptBuilder.ts
@@ -87,10 +87,16 @@ abstract class ScriptBuilderImpl<S = Task | Automation> implements ScriptBuilder
   }
 
   addWait(ref: NodeRef, seconds: number): ScriptBuilder<S> {
+    if (seconds < 0) {
+      this.errors.push(InvalidScriptError("The wait instruction needs positive numbers"))
+    }
     return this.createCopy(ref, WaitInstruction(seconds))
   }
 
   addSendNotification(ref: NodeRef, email: Email, message: string): ScriptBuilder<S> {
+    if (email.length === 0) {
+      this.errors.push(InvalidScriptError("The email to which send the notification cannot be empty"))
+    }
     return this.createCopy(ref, SendNotificationInstruction(email, message))
   }
 
@@ -99,10 +105,16 @@ abstract class ScriptBuilderImpl<S = Task | Automation> implements ScriptBuilder
   }
 
   addStartTask(ref: NodeRef, taskId: TaskId): ScriptBuilder<S> {
+    if (taskId.length === 0) {
+      this.errors.push(InvalidScriptError("The start task instruction needs the name of a task"))
+    }
     return this.createCopy(ref, StartTaskInstruction(taskId))
   }
 
   private addConstantInstructionToBuilder(ref: NodeRef, instruction: ConstantInstruction<unknown>): [ScriptBuilder<S>, ConstantRef] {
+    if (instruction.name.length === 0) {
+      this.errors.push(InvalidScriptError("Constants cannot have empty name"))
+    } 
     const constantRef = ConstantRef(instruction, ref)
     return [
       this.createCopy(ref, instruction),

--- a/src/domain/scripts-management/ScriptBuilder.ts
+++ b/src/domain/scripts-management/ScriptBuilder.ts
@@ -158,6 +158,9 @@ abstract class ScriptBuilderImpl<S = Task | Automation> implements ScriptBuilder
 
 class TaskBuilderImpl extends ScriptBuilderImpl<Task> {
   build(): Effect<Task, InvalidScriptError> {
+    if (this.name.length === 0) {
+      this.errors.push(InvalidScriptError("The name of the task cannot be empty"))
+    }
     return this.buildWithId(TaskId(uuid.v4()))
   }
 
@@ -196,6 +199,9 @@ class AutomationBuilderImpl extends ScriptBuilderImpl<Automation> {
   }
 
   build(): Effect<Automation, InvalidScriptError> {
+    if (this.name.length === 0) {
+      this.errors.push(InvalidScriptError("The name of the automation cannot be empty"))
+    }
     return this.buildWithId(AutomationId(uuid.v4()))
   }
 

--- a/src/domain/scripts-management/ScriptsServiceImpl.ts
+++ b/src/domain/scripts-management/ScriptsServiceImpl.ts
@@ -80,6 +80,19 @@ export class ScriptsServiceImpl implements ScriptsService, DeviceEventsSubscribe
             failure: "EditListNotFoundError",
             onFailure: () => succeed(undefined)
           }),
+          catch_("__brand", {
+            failure: "UserNotFoundError",
+            onFailure: () => {
+              return pipe(
+                this.scriptRepository.remove(script.id),
+                flatMap(() => fail(InvalidTokenError("This token references a deleted user")))
+              )
+            }
+          }),
+          catch_("__brand", {
+            failure: "NotFoundError",
+            onFailure: () => succeed(undefined)
+          }),
           flatMap(() => succeed(script.id))
         )
       ),
@@ -90,7 +103,6 @@ export class ScriptsServiceImpl implements ScriptsService, DeviceEventsSubscribe
             case "DuplicateIdError":
             case "UniquenessConstraintViolatedError":
               return TaskNameAlreadyInUseError(err.cause)
-            case "UserNotFoundError": return InvalidTokenError("This token references a deleted user")
           }
         }
         return err

--- a/src/domain/scripts-management/ScriptsServiceImpl.ts
+++ b/src/domain/scripts-management/ScriptsServiceImpl.ts
@@ -178,6 +178,19 @@ export class ScriptsServiceImpl implements ScriptsService, DeviceEventsSubscribe
             failure: "EditListNotFoundError",
             onFailure: () => succeed(undefined)
           }),
+          catch_("__brand", {
+            failure: "UserNotFoundError",
+            onFailure: () => {
+              return pipe(
+                this.scriptRepository.remove(automation.id),
+                flatMap(() => fail(InvalidTokenError("This token references a deleted user")))
+              )
+            }
+          }),
+          catch_("__brand", {
+            failure: "NotFoundError",
+            onFailure: () => succeed(undefined)
+          }),
           flatMap(() => succeed(automation.id))
         )
       ),
@@ -196,7 +209,6 @@ export class ScriptsServiceImpl implements ScriptsService, DeviceEventsSubscribe
             case "DuplicateIdError":
             case "UniquenessConstraintViolatedError":
               return AutomationNameAlreadyInUseError(err.cause)
-            case "UserNotFoundError": return InvalidTokenError("This token references a deleted user")
           }
         }
         return err

--- a/src/domain/scripts-management/ScriptsServiceImpl.ts
+++ b/src/domain/scripts-management/ScriptsServiceImpl.ts
@@ -163,12 +163,11 @@ export class ScriptsServiceImpl implements ScriptsService, DeviceEventsSubscribe
   }
 
   private removeOrRecreateAutomation(oldAutomation: Automation | undefined, automation: Automation): Effect<void, NotFoundError | DuplicateIdError | UniquenessConstraintViolatedError> {
-    if (oldAutomation === undefined)
-      // If creating, remove the automation 
-      return this.scriptRepository.remove(automation.id)
-    else
-      // If editing, recreate the old automation
-      return this.scriptRepository.add(oldAutomation)
+    // Remove the new automation and then, if editing, recreate the old one
+    return pipe(
+      this.scriptRepository.remove(automation.id),
+      flatMap(() => oldAutomation ? this.scriptRepository.add(oldAutomation) : succeed(undefined))
+    )
   }
 
   createAutomation(token: Token, automation: AutomationBuilder, oldAutomation: Automation | undefined = undefined): Effect<AutomationId, InvalidTokenError | AutomationNameAlreadyInUseError | InvalidScriptError | PermissionError> {


### PR DESCRIPTION
# Fixes changelog
- Add new syntactic errors to the scriptsBuilder:
  - Email of send notification cannot be empty
  - TaskId of start task cannot be empty
  - TaskId of start task cannot referece the same task in which it is present
  - Constant names cannot be empty
  - The script needs a name
  - The types on the if must be the same
  - Seconds on wait instruction must be positive
  - PeriodSeconds on period trigger must be positive
- Now when creating a task or an automation, if the token references a deleted user, the script will not be created (the check is done in the permissionsService.addToEditlistUnsafe method)
- Now when editing an automation, get the old automation and pass it to the createAutomation after having deleted it, so that the createAutomation has all the logic for creation or editing based on oldAutomation != undefined
- When editing automation with a deleted user add the old automation that has been removed after deleting the new one.
- If the new automation (editing mode) is not valid (syntax), then recreate the old automation and fail